### PR TITLE
feat: add /api/version route for vscode copilot's newest version

### DIFF
--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -46,3 +46,7 @@ async def chat_completions(request: Request):
             res = await client.post("/chat/completions", json=data)
             res.raise_for_status()
             return res.json()
+
+@app.get("/api/version")
+async def version():
+    return {"version": "0.11.0"}


### PR DESCRIPTION
## in short
VSCode's newest Github Copilot plugin now sends a GET /api/version request on initialization. This route is currently missing, causing 404 errors and preventing these clients from connecting.

This change adds a simple /api/version endpoint returning:
    {"version": "0.11.0"}

This matches the expected Ollama API shape and improves compatibility without breaking existing functionality.

## detailed explaination
When using oai2ollama as a local proxy, certain clients (e.g., Ollama CLI and VSCode GitHub Copilot) send a GET /api/version request during initialization.
Currently, this route is not implemented, which results in:
```
"GET /api/version HTTP/1.1" 404 Not Found
```
This causes some clients to fail during connection checks.

### Proposed Solution
Add a GET /api/version route to the FastAPI application that returns a static JSON object in the same shape as Ollama’s API, for example:
```
{"version": "0.11.0"}
```
### Rationale

Improves compatibility with tools expecting Ollama’s API surface.
Tested successfully on:
- VSCode GitHub Copilot 1.353.1722 (pre-release, updated 2025-08-08)
- VSCode GitHub Copilot 1.350.0 (stable)
- VSCode GitHub Copilot 1.210 (from ~1 year ago)

### Impact
No breaking changes. This adds a single route for improved compatibility without affecting existing endpoints.

### attachments
screen shots demonstrationg how the updated oai2ollama module works the same.

<img width="500" height="350" alt="alt models" src="https://github.com/user-attachments/assets/b135a9fb-4f0d-4c3d-99ef-9d7d4be49eb5" />
<img width="630" height="420" alt="edit mode" src="https://github.com/user-attachments/assets/5afb6e44-3a86-44e1-8fee-d9b19b9a9a8c" />
<img width="370" height="500" alt="ask mode" src="https://github.com/user-attachments/assets/a635d3e3-6aee-4f89-b708-ff4d31704ab7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增了 `/api/version` 接口，可用于获取当前应用的版本信息（0.11.0）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->