### PR TITLE
feat: add `/v1/models` compatible api

### DIFF
--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -27,6 +27,13 @@ async def show_model():
         "capabilities": ["completion", *env.capabilities],
     }
 
+@app.get("/v1/models")
+async def list_models():
+    async with _new_client() as client:
+        res.raise_for_status()
+        res = await client.get("/models")
+        return res.json()
+
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: Request):

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -27,6 +27,7 @@ async def show_model():
         "capabilities": ["completion", *env.capabilities],
     }
 
+
 @app.get("/v1/models")
 async def list_models():
     async with _new_client() as client:

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -30,8 +30,8 @@ async def show_model():
 @app.get("/v1/models")
 async def list_models():
     async with _new_client() as client:
-        res.raise_for_status()
         res = await client.get("/models")
+        res.raise_for_status()
         return res.json()
 
 


### PR DESCRIPTION
Ollama has this api for compatibility, and vscode copilot uses it in recent updates

> 8月 20 17:27:22 zyc-Laptop oai2ollama[29258]: INFO:     Uvicorn running on http://localhost:11434 (Press CTRL+C to quit)
> 8月 20 17:27:29 zyc-Laptop oai2ollama[29258]: INFO:     ::1:57836 - "GET /v1/models HTTP/1.1" 404 Not Found




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增公开接口 GET /v1/models，用于获取可用模型列表，便于客户端发现与选择模型。
  - 接口返回标准 JSON 响应，行为与现有路由一致，便于前端展示与集成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->