### PR TITLE
add --models param to manual add return tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ uvx oai2ollama --help
 ```
 
 ```text
-usage: oai2ollama [--api-key str] [--base-url HttpUrl] [--capabilities list[str]] [--host str]
+usage: oai2ollama [--api-key str] [--base-url HttpUrl] [--capabilities list[str]] [--models list[str]] [--host str]
 options:
   --help, -h                    Show this help message and exit
   --api-key str                 API key for authentication (required)
   --base-url HttpUrl            Base URL for the OpenAI-compatible API (required)
   --capabilities, -c list[str]  Extra capabilities to mark the model as supporting
+  --models, -m list[str]        Extra models to include in the /api/tags response
   --host str                    IP / hostname for the API server (default: localhost)
 ```
 
@@ -30,6 +31,10 @@ options:
 > `oai2ollama -c tools` or `oai2ollama --capabilities tools`
 >
 > `oai2ollama -c tools -c vision` or `oai2ollama --capabilities -c tools,vision`
+>
+> To support models that are not returned by the `/models` endpoint, use the `--models` (or `-m`) option to add them to the `/api/tags` response:
+>
+> `oai2ollama -m model1 -m model2` or `oai2ollama -m model1,model2`
 >
 > Capabilities currently [used by Ollama](https://github.com/ollama/ollama/blob/main/types/model/capability.go#L6-L11) are:
 > `tools`, `insert`, `vision`, `embedding`, `thinking` and `completion`. We always include `completion`.
@@ -41,6 +46,7 @@ OPENAI_API_KEY=your_api_key
 OPENAI_BASE_URL=your_base_url
 HOST=0.0.0.0
 CAPABILITIES=["vision","thinking"]
+MODELS=["custom-model1","custom-model2"]
 ```
 
 > [!WARNING]

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -35,7 +35,6 @@ async def models():
                 deduped_models.append(m)
                 seen.add(m["name"])
 
-        print({"models": deduped_models})
         return {"models": deduped_models}
 
 

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -15,27 +15,10 @@ def _new_client():
 @app.get("/api/tags")
 async def models():
     async with _new_client() as client:
-        res = await client.get("/models")  # Replace with the actual API endpoint
+        res = await client.get("/models")
         res.raise_for_status()
-
-        # Get original models from API response
-        original_models = [{"name": i["id"], "model": i["id"]} for i in res.json()["data"]]
-
-        # Add additional models from config
-        if env.models:
-            additional_models = [{"name": model.strip(), "model": model.strip()}
-                               for model in env.models.split(",") if model.strip()]
-            original_models.extend(additional_models)
-
-        # Deduplicate models by "name", preserving first occurrence
-        seen = set()
-        deduped_models = []
-        for m in original_models:
-            if m["name"] not in seen:
-                deduped_models.append(m)
-                seen.add(m["name"])
-
-        return {"models": deduped_models}
+        models_map = {i["id"]: {"name": i["id"], "model": i["id"]} for i in res.json()["data"]} | {i: {"name": i, "model": i} for i in env.models}
+        return {"models": list(models_map.values())}
 
 
 @app.post("/api/show")

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -17,7 +17,7 @@ async def models():
     async with _new_client() as client:
         res = await client.get("/models")
         res.raise_for_status()
-        models_map = {i["id"]: {"name": i["id"], "model": i["id"]} for i in res.json()["data"]} | {i: {"name": i, "model": i} for i in env.models}
+        models_map = {i["id"]: {"name": i["id"], "model": i["id"]} for i in res.json()["data"]} | {i: {"name": i, "model": i} for i in env.extra_models}
         return {"models": list(models_map.values())}
 
 

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -27,8 +27,16 @@ async def models():
                                for model in env.models.split(",") if model.strip()]
             original_models.extend(additional_models)
 
-        print({"models": original_models})
-        return {"models": original_models}
+        # Deduplicate models by "name", preserving first occurrence
+        seen = set()
+        deduped_models = []
+        for m in original_models:
+            if m["name"] not in seen:
+                deduped_models.append(m)
+                seen.add(m["name"])
+
+        print({"models": deduped_models})
+        return {"models": deduped_models}
 
 
 @app.post("/api/show")

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -17,7 +17,18 @@ async def models():
     async with _new_client() as client:
         res = await client.get("/models")  # Replace with the actual API endpoint
         res.raise_for_status()
-        return {"models": [{"name": i["id"], "model": i["id"]} for i in res.json()["data"]]}
+
+        # Get original models from API response
+        original_models = [{"name": i["id"], "model": i["id"]} for i in res.json()["data"]]
+
+        # Add additional models from config
+        if env.models:
+            additional_models = [{"name": model.strip(), "model": model.strip()}
+                               for model in env.models.split(",") if model.strip()]
+            original_models.extend(additional_models)
+
+        print({"models": original_models})
+        return {"models": original_models}
 
 
 @app.post("/api/show")

--- a/oai2ollama/config.py
+++ b/oai2ollama/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     capacities: CliSuppress[list[Literal["tools", "insert", "vision", "embedding", "thinking"]]] = Field([], repr=False)
     capabilities: list[Literal["tools", "insert", "vision", "embedding", "thinking"]] = []
     host: str = Field("localhost", description="IP / hostname for the API server")
-    models: list[str] = Field([], description="Extra models to include in the /api/tags response")
+    extra_models: list[str] = Field([], description="Extra models to include in the /api/tags response", alias="models")
 
     @model_validator(mode="after")
     def _warn_legacy_capacities(self: Self):

--- a/oai2ollama/config.py
+++ b/oai2ollama/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     capacities: CliSuppress[list[Literal["tools", "insert", "vision", "embedding", "thinking"]]] = Field([], repr=False)
     capabilities: list[Literal["tools", "insert", "vision", "embedding", "thinking"]] = []
     host: str = Field("localhost", description="IP / hostname for the API server")
-    models: str = Field("", description="Comma-separated list of model names to add to /api/tags")
+    models: list[str] = Field([], description="Extra models to include in the /api/tags response")
 
     @model_validator(mode="after")
     def _warn_legacy_capacities(self: Self):

--- a/oai2ollama/config.py
+++ b/oai2ollama/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
         "extra": "ignore",
         "cli_shortcuts": {
             "capabilities": "c",
+            "models": "m",
         },
     }
 
@@ -22,6 +23,7 @@ class Settings(BaseSettings):
     capacities: CliSuppress[list[Literal["tools", "insert", "vision", "embedding", "thinking"]]] = Field([], repr=False)
     capabilities: list[Literal["tools", "insert", "vision", "embedding", "thinking"]] = []
     host: str = Field("localhost", description="IP / hostname for the API server")
+    models: str = Field("", description="Comma-separated list of model names to add to /api/tags")
 
     @model_validator(mode="after")
     def _warn_legacy_capacities(self: Self):


### PR DESCRIPTION
add --models -m param to manual set /api/tags extend models return for more setting
for example glm-4.5-x can't return by official /models request , have to add models to copilot to use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - /api/tags 现在将远端返回的模型与通过环境变量或新的命令行选项 models（短参 -m）提供的自定义模型合并、按名称去重并统一展示可用模型列表。
- **其他**
  - 文档（README）新增 --models / -m 用法示例；移除请求中的占位注释，错误处理和现有接口行为保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->