### PR TITLE
Enhance show_model endpoint to modify context_length in VSCode

### DIFF
--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -27,9 +27,18 @@ async def models(client=_new_client):
 
 
 @app.post("/api/show")
-async def show_model():
+async def show_model(request: Request):
+    data = await request.json()
+    model = data.get("model")
+    model_info: dict[str, str | int] = {"general.architecture": "CausalLM"}
+
+    # Add context_length if configured for this model
+    if model and model in env.context_lengths:
+        model_info["general.architecture"] = model
+        model_info[model + ".context_length"] = env.context_lengths[model]
+
     return {
-        "model_info": {"general.architecture": "CausalLM"},
+        "model_info": model_info,
         "capabilities": ["completion", *env.capabilities],
     }
 

--- a/oai2ollama/config.py
+++ b/oai2ollama/config.py
@@ -1,9 +1,15 @@
+import re
 from os import getenv
 from sys import stderr
 from typing import Literal, Self
 
-from pydantic import Field, HttpUrl, ValidationError, model_validator
+from pydantic import Field, HttpUrl, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, CliSuppress
+
+
+class InvalidContextLengthError(ValueError):
+    def __init__(self):
+        super().__init__("invalid context length")
 
 
 class Settings(BaseSettings):
@@ -15,6 +21,7 @@ class Settings(BaseSettings):
         "cli_shortcuts": {
             "capabilities": "c",
             "models": "m",
+            "context-lengths": "l",
         },
     }
 
@@ -24,6 +31,30 @@ class Settings(BaseSettings):
     capabilities: list[Literal["tools", "insert", "vision", "embedding", "thinking"]] = []
     host: str = Field("localhost", description="IP / hostname for the API server")
     extra_models: list[str] = Field([], description="Extra models to include in the /api/tags response", alias="models")
+    context_lengths: dict[str, int] = Field({}, description='Context length for specific models, e.g. {"model-name": 4096}')
+
+    @field_validator("context_lengths", mode="before")
+    @classmethod
+    def _parse_context_lengths(cls, value):
+        def _parse_context_length(value: int | str) -> int:
+            if isinstance(value, int):
+                return value
+
+            parsed = re.fullmatch(r"\s*(\d+)\s*([kKmM]?)\s*", value)
+            if not parsed:
+                raise InvalidContextLengthError
+
+            amount = int(parsed.group(1))
+            suffix = parsed.group(2).lower()
+            if suffix == "k":
+                return amount * 1000
+            if suffix == "m":
+                return amount * 1000 * 1000
+            return amount
+
+        if not isinstance(value, dict):
+            return value
+        return {k: _parse_context_length(v) for k, v in value.items()}
 
     @model_validator(mode="after")
     def _warn_legacy_capacities(self: Self):


### PR DESCRIPTION
This pull request introduces support for specifying context lengths for individual models in the configuration, and updates the API to return this information when requested. The changes also include improved parsing and validation for context length values, as well as updates to CLI shortcuts.

Configuration enhancements:

* Added a `context_lengths` field to the `Settings` class, allowing configuration of context length per model.
* Implemented a `field_validator` for `context_lengths` to parse values with optional suffixes (e.g., "4k" for 4000), and handle invalid input with a custom error [[1]](diffhunk://#diff-f6cbfa8ab3cd59198eb966704b4fdef3adc5b66722263ec78c0ec3666042d6c2R1-R14) [[2]](diffhunk://#diff-f6cbfa8ab3cd59198eb966704b4fdef3adc5b66722263ec78c0ec3666042d6c2R34-R57).

API improvements:

* Modified the `/api/show` endpoint to accept a model name, and return its context length if configured, along with its architecture.

CLI usability:

* Added a new shortcut for `context-lengths` to the CLI configuration.

---

This modification is primarily intended to increase the context length for Ollama models within VS Code, as the default limit is only 33k tokens.

Source of inspiration: https://github.com/microsoft/vscode/issues/302475