### PR TITLE
feat: add monitoring with maping

### DIFF
--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -12,13 +12,13 @@ recorder = Recorder(service="oai2ollama")
 
 
 @asynccontextmanager
-async def _lifespan(_app: FastAPI):
+async def _lifespan(app: FastAPI):
     await recorder.start()
     yield
     await recorder.shutdown()
 
 
-_app = FastAPI(lifespan=_lifespan)
+app = FastAPI(lifespan=_lifespan)
 
 
 @Depends
@@ -29,7 +29,7 @@ async def _new_client():
         yield client
 
 
-@_app.get("/api/tags")
+@app.get("/api/tags")
 async def models(client=_new_client):
     res = await client.get("/models")
     res.raise_for_status()
@@ -41,7 +41,7 @@ async def models(client=_new_client):
     return {"models": list(models_map.values())}
 
 
-@_app.post("/api/show")
+@app.post("/api/show")
 async def show_model():
     return {
         "model_info": {"general.architecture": "CausalLM"},
@@ -49,14 +49,14 @@ async def show_model():
     }
 
 
-@_app.get("/v1/models")
+@app.get("/v1/models")
 async def list_models(client=_new_client):
     res = await client.get("/models")
     res.raise_for_status()
     return res.json()
 
 
-@_app.post("/v1/chat/completions")
+@app.post("/v1/chat/completions")
 async def chat_completions(request: Request, client=_new_client):
     data = await request.json()
 
@@ -75,9 +75,10 @@ async def chat_completions(request: Request, client=_new_client):
         return res.json()
 
 
-@_app.get("/api/version")
+@app.get("/api/version")
 async def ollama_version():
     return {"version": "0.12.10"}
 
 
-app = MapingMiddleware(_app, recorder=recorder) if os.environ.get("MAPING_KEY") else _app
+if os.environ.get("MAPING_KEY"):
+    app = MapingMiddleware(app, recorder=recorder)

--- a/oai2ollama/_app.py
+++ b/oai2ollama/_app.py
@@ -1,9 +1,24 @@
+import os
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import StreamingResponse
+from maping import Recorder
+from maping.asgi import MapingMiddleware
 
 from .config import env
 
-app = FastAPI()
+recorder = Recorder(service="oai2ollama")
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    await recorder.start()
+    yield
+    await recorder.shutdown()
+
+
+_app = FastAPI(lifespan=_lifespan)
 
 
 @Depends
@@ -14,7 +29,7 @@ async def _new_client():
         yield client
 
 
-@app.get("/api/tags")
+@_app.get("/api/tags")
 async def models(client=_new_client):
     res = await client.get("/models")
     res.raise_for_status()
@@ -26,7 +41,7 @@ async def models(client=_new_client):
     return {"models": list(models_map.values())}
 
 
-@app.post("/api/show")
+@_app.post("/api/show")
 async def show_model():
     return {
         "model_info": {"general.architecture": "CausalLM"},
@@ -34,14 +49,14 @@ async def show_model():
     }
 
 
-@app.get("/v1/models")
+@_app.get("/v1/models")
 async def list_models(client=_new_client):
     res = await client.get("/models")
     res.raise_for_status()
     return res.json()
 
 
-@app.post("/v1/chat/completions")
+@_app.post("/v1/chat/completions")
 async def chat_completions(request: Request, client=_new_client):
     data = await request.json()
 
@@ -60,6 +75,9 @@ async def chat_completions(request: Request, client=_new_client):
         return res.json()
 
 
-@app.get("/api/version")
+@_app.get("/api/version")
 async def ollama_version():
     return {"version": "0.12.10"}
+
+
+app = MapingMiddleware(_app, recorder=recorder) if os.environ.get("MAPING_KEY") else _app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "dotenv-pth~=1.0.0",
     "fastapi>=0.140.13,<0.142.0",
     "httpx[http2]~=0.28.1",
+    "maping-client>=0.1.0",
     "pydantic-settings>=2.10.1,<2.15.0",
     "uvicorn-hmr~=0.1.1",
 ]


### PR DESCRIPTION
Hi!

I noticed oai2ollama project doesn't seem to have application monitoring, so I added it using [mAPI-ng](https://www.mapi-ng.com/), a lightweight API monitoring tool I'm developing.

The integration provides endpoint-level traffic, error rates, latency percentiles, and request/response sizes.

This PR is safe to merge as-is: without a MAPING_KEY, the integration stays inactive and doesn't affect the application.

If you'd like to try it, MAPING has a free tier with no credit card required. Creating an account at [mapi-ng.com](https://www.mapi-ng.com/) gives you the MAPING_KEY needed to enable monitoring.

## Changes

* Add the MAPING Python client
* Configure MAPING monitoring for the application
* Read the ingest key from the MAPING_KEY environment variable
* Remain inactive when MAPING_KEY isn't configured

## Screenshots

This is MAPING running against this project during my test of the integration:

<img width="1312" height="759" alt="oai2ollama_maping" src="https://github.com/user-attachments/assets/02f583cc-943d-4ae6-8309-2a9359814f76" />


## Checklist

* Manually tested the MAPING integration
* No secrets or credentials committed

## Notes
Full disclosure: I'm the author of MAPING.

What I'm mainly looking for is feedback from rea projects: whether the integration is useful, what feels awkward, and what's missing.

The hosted service isn't required: MAPING can also be fully self-hosted with all features available, so adopting the client doesn't lock the project into mapi-ng.com.

**If monitoring isn't relevant to this project, feel free to close the PR, no worries.**

Submitted under this project's existing license (AGPL-3.0), matching the rest of the diff.